### PR TITLE
throw runtime exception if cannot get outline temporarily

### DIFF
--- a/org.elastic.jdt.ls.core/src/org/elastic/jdt/ls/core/internal/FullHandler.java
+++ b/org.elastic.jdt.ls.core/src/org/elastic/jdt/ls/core/internal/FullHandler.java
@@ -57,6 +57,9 @@ public class FullHandler {
 			return new Full(symbols, references);
 		} catch (JavaModelException e) {
 			JavaLanguageServerPlugin.logException("Problem getting outline for" +  unit.getElementName(), e);
+			if (e.getMessage().indexOf("exist") != -1) {
+				throw new RuntimeException("temporarily unavailable");
+			}
 		}
 		return null;
 	}


### PR DESCRIPTION
The json-rpc response will be like:
```
{"id":14,"content":"{\"jsonrpc\":\"2.0\",\"id\":188,\"error\":{\"code\":-32603,\"message\":\"Internal error.\",\"data\":\"java.util.concurrent.CompletionException: 
java.lang.RuntimeException: temporarily unavailable\
\	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:273)\
\	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:280)\
\	at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:604)\
\	at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:577)\
\	at java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:443)\
```