### PR TITLE
Fix ant project importer and add basic test

### DIFF
--- a/org.elastic.jdt.ls.core/src/org/elastic/jdt/ls/core/internal/AntProjectImporter.java
+++ b/org.elastic.jdt.ls.core/src/org/elastic/jdt/ls/core/internal/AntProjectImporter.java
@@ -6,6 +6,7 @@ import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.ls.core.internal.AbstractProjectImporter;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.managers.BasicFileDetector;
@@ -63,9 +64,12 @@ public class AntProjectImporter extends AbstractProjectImporter {
 				// TODO:pcxu add a configuration to figure out which javac task to use
 				try {
 					Javac javacTask = (Javac) javacTasks.get(0);
-					pc.createJavaProjectFromJavacNode(project.getParent().getFileName().toString(), javacTask, monitor);
+					IJavaProject javaProject = pc.createJavaProjectFromJavacNode(project.getFileName().toString(), javacTask, subMonitor);
+					if (javaProject == null) {
+						JavaLanguageServerPlugin.logError("ant project is null");
+					}
 				} catch (Exception e) {
-					//
+					JavaLanguageServerPlugin.logException("import ant project error", e);
 				}
 			}
 

--- a/org.elastic.jdt.ls.tests/META-INF/MANIFEST.MF
+++ b/org.elastic.jdt.ls.tests/META-INF/MANIFEST.MF
@@ -30,6 +30,6 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.xtext.xbase.lib,
  org.eclipse.jdt.launching,
  org.elastic.jdt.ls.core,
- org.eclipse.jdt.ls.core;bundle-version="0.24.0"
+ org.eclipse.jdt.ls.core
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Activator: org.elastic.jdt.ls.core.internal.JavaLanguageServerTestPlugin

--- a/org.elastic.jdt.ls.tests/projects/ant/salut/build.xml
+++ b/org.elastic.jdt.ls.tests/projects/ant/salut/build.xml
@@ -1,0 +1,39 @@
+<project name="salut" basedir="." default="main">
+
+    <property name="src.dir"     value="src"/>
+
+    <property name="build.dir"   value="build"/>
+    <property name="classes.dir" value="${build.dir}/classes"/>
+    <property name="jar.dir"     value="${build.dir}/jar"/>
+
+    <property name="main-class"  value="org.sample.Bar"/>
+
+
+
+    <target name="clean">
+        <delete dir="${build.dir}"/>
+    </target>
+
+    <target name="compile">
+        <mkdir dir="${classes.dir}"/>
+        <javac srcdir="${src.dir}" destdir="${classes.dir}"/>
+    </target>
+
+    <target name="jar" depends="compile">
+        <mkdir dir="${jar.dir}"/>
+        <jar destfile="${jar.dir}/${ant.project.name}.jar" basedir="${classes.dir}">
+            <manifest>
+                <attribute name="Main-Class" value="${main-class}"/>
+            </manifest>
+        </jar>
+    </target>
+
+    <target name="run" depends="jar">
+        <java jar="${jar.dir}/${ant.project.name}.jar" fork="true"/>
+    </target>
+
+    <target name="clean-build" depends="clean,jar"/>
+
+    <target name="main" depends="clean,run"/>
+
+</project>

--- a/org.elastic.jdt.ls.tests/projects/ant/salut/src/main/java/org/sample/Bar.java
+++ b/org.elastic.jdt.ls.tests/projects/ant/salut/src/main/java/org/sample/Bar.java
@@ -1,0 +1,21 @@
+package org.sample;
+
+/**
+ * This is Bar
+ */
+public class Bar {
+
+	public static void main(String[] args) {
+      System.out.print( "Hello world! from "+Bar.class);
+	}
+	
+	public static interface MyInterface {
+		
+		void foo();
+	}
+	
+	public static class MyClass {
+		
+		void bar() {}
+	}
+}

--- a/org.elastic.jdt.ls.tests/src/org/elastic/jdt/ls/core/internal/AbstractAntBasedTest.java
+++ b/org.elastic.jdt.ls.tests/src/org/elastic/jdt/ls/core/internal/AbstractAntBasedTest.java
@@ -1,0 +1,22 @@
+package org.elastic.jdt.ls.core.internal;
+
+import static org.elastic.jdt.ls.core.internal.WorkspaceHelper.getProject;
+import static org.junit.Assert.assertNotNull;
+
+import org.eclipse.core.resources.IProject;
+import org.elastic.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+
+/**
+ * @author Pengcheng Xu
+ *
+ */
+public abstract class AbstractAntBasedTest extends AbstractProjectsManagerBasedTest {
+
+    protected IProject importAntProject(String name) throws Exception {
+        importProjects("ant/"+name);
+		IProject project = getProject(name);
+		assertNotNull(project);
+		return project;
+	}
+
+}

--- a/org.elastic.jdt.ls.tests/src/org/elastic/jdt/ls/core/internal/AntProjectImporterTest.java
+++ b/org.elastic.jdt.ls.tests/src/org/elastic/jdt/ls/core/internal/AntProjectImporterTest.java
@@ -1,0 +1,16 @@
+package org.elastic.jdt.ls.core.internal;
+
+import org.junit.Test;
+
+/**
+ * @author poytr1
+ *
+ */
+public class AntProjectImporterTest extends AbstractAntBasedTest {
+
+	@Test
+	public void testImportSimpleJavaProject() throws Exception {
+		importAntProject("salut");
+	}
+
+}


### PR DESCRIPTION
Errors in https://github.com/elastic/code/issues/749 automatically disappear after updating the dependency (https://github.com/elastic/java-langserver/pull/30)