### PR TITLE
Fix user id and .m2 permission

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -15,10 +15,15 @@ apt-get -qq -y autoremove && \
 apt-get -qq -y clean && \
 rm -rf /var/lib/apt/lists/*
 
+# Update the current node user id (1000)
+# because it might be the CI user id we want
+# to create.
+RUN usermod -u 15000 node
+
 ####
 # Build CI User
 ###
-ARG CI_USER_UID=13000
+ARG CI_USER_UID=1000
 ENV CI_USER ciagent
 ENV CI_GROUP ciagent
 ENV HOME /home/${CI_USER}

--- a/.ci/script/docker/package.sh
+++ b/.ci/script/docker/package.sh
@@ -45,7 +45,7 @@ docker run \
     --rm -t $(tty &>/dev/null && echo "-i") \
     --user $(id -u):ciagent \
     -v "$(pwd):/plugin/kibana-extra/java-langserver:rw" \
-    -v "$HOME/.m2":/home/ciagent/.m2 \
+    --mount source=m2-vol,destination=/home/ciagent/.m2 \
     $KIBANA_MOUNT_ARGUMENT \
     code-lsp-java-langserver-ci \
     /bin/bash -c "set -ex


### PR DESCRIPTION
By introducing a new CI user for running the build in #52, we
encountered two problems (as explained in https://github.com/elastic/java-langserver/pull/52#issuecomment-494781989)

First one is that the CI user id we are creating in the Docker image
could be the same as the node user (1000), because it's a common value.
This commit fixes it by updating the node user id.

The second problem is a permission issue when mounting the .m2
folder into the container, which prevents Maven to work.
This commit fixes it by using a Docker volume for the .m2 cache.
It means that the cache can be shared between all builds while the `m2-vol`
volume is not deleted.

I have tested it in the release manager VM