### PR TITLE
Dont initialize diagnostics handler

### DIFF
--- a/org.elastic.jdt.ls.core/src/org/elastic/jdt/ls/core/internal/ElasticJDTLanguageServer.java
+++ b/org.elastic.jdt.ls.core/src/org/elastic/jdt/ls/core/internal/ElasticJDTLanguageServer.java
@@ -129,6 +129,7 @@ public class ElasticJDTLanguageServer extends JDTLanguageServer {
 				try {
 					JobHelpers.waitForBuildJobs(60 * 60 * 1000); // 1 hour
 					logInfo(">> build jobs finished");
+					// Dont initialize DiagnosticsHandler here
 				} catch (OperationCanceledException e) {
 					logException(e.getMessage(), e);
 					return Status.CANCEL_STATUS;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1058,10 +1058,15 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0, commander@^2.20.0, commander@^2.9.0:
+commander@^2.11.0, commander@^2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+
+commander@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.0.tgz#0641ea00838c7a964627f04cddc336a2deddd60a"
+  integrity sha512-pl3QrGOBa9RZaslQiqnnKX2J068wcQw7j9AIaBQ9/JEp5RY6je4jKTImg0Bd+rpoONSe7GUFSgkxLeo17m3Pow==
 
 commondir@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Resolve: https://github.com/elastic/code/issues/1518

Override the `initialized` method of the super class, delete the code related to initializing the diagnostics handler