### PR TITLE
[7.x] Use eclipse.jdt.ls 0.41.0 (#92)

### DIFF
--- a/org.elastic.jdt.ls.target/org.elastic.jdt.ls.tp.target
+++ b/org.elastic.jdt.ls.target/org.elastic.jdt.ls.tp.target
@@ -33,13 +33,13 @@
             <repository location="https://download.eclipse.org/eclipse/updates/4.13-I-builds/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.6.0.v20181130-0905"/>
-            <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.6.0"/>
-        </location>
+		    <repository location="http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastSuccessfulBuild/artifact/build/p2-repository/"/>
+		    <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
+	    </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/releases/2019-03/"/>
+            <repository location="https://download.eclipse.org/releases/2019-06/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.jboss.tools.maven.apt.core" version="0.0.0"/>

--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
 		<repository>
 			<id>jdt.ls</id>
 			<layout>p2</layout>
-			<url>https://download.eclipse.org/jdtls/milestones/0.40.0/repository/</url>
+			<url>https://download.eclipse.org/jdtls/milestones/0.41.0/repository/</url>
 		</repository>
 	</repositories>
 	<profiles>


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Use eclipse.jdt.ls 0.41.0 (#92)