### PR TITLE
[7.x] Dont initialize diagnostics handler (#91)

### DIFF
--- a/org.elastic.jdt.ls.core/src/org/elastic/jdt/ls/core/internal/ElasticJDTLanguageServer.java
+++ b/org.elastic.jdt.ls.core/src/org/elastic/jdt/ls/core/internal/ElasticJDTLanguageServer.java
@@ -1,26 +1,35 @@
 package org.elastic.jdt.ls.core.internal;
 
 import static org.elastic.jdt.ls.core.internal.ElasticJavaLanguageServerPlugin.logInfo;
+import static org.elastic.jdt.ls.core.internal.ElasticJavaLanguageServerPlugin.logException;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import org.apache.commons.lang3.reflect.MethodUtils;
+
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.manipulation.CoreASTProvider;
 import org.eclipse.jdt.ls.core.internal.CancellableProgressMonitor;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.handlers.InitHandler;
+import org.eclipse.jdt.ls.core.internal.handlers.CompletionHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.DocumentLifeCycleHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.DocumentSymbolHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.JobHelpers;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
@@ -70,6 +79,67 @@ public class ElasticJDTLanguageServer extends JDTLanguageServer {
 			JavaLanguageServerPlugin.logException(e.getMessage(), e);
 		}
 		return result;
+	}
+
+	@Override
+	public void initialized(InitializedParams params) {
+		logInfo(">> initialized");
+		if (preferenceManager.getClientPreferences().isCompletionDynamicRegistered()) {
+			registerCapability(Preferences.COMPLETION_ID, Preferences.COMPLETION, CompletionHandler.DEFAULT_COMPLETION_OPTIONS);
+		}
+		if (preferenceManager.getClientPreferences().isWorkspaceSymbolDynamicRegistered()) {
+			registerCapability(Preferences.WORKSPACE_SYMBOL_ID, Preferences.WORKSPACE_SYMBOL);
+		}
+		if (preferenceManager.getClientPreferences().isDocumentSymbolDynamicRegistered()) {
+			registerCapability(Preferences.DOCUMENT_SYMBOL_ID, Preferences.DOCUMENT_SYMBOL);
+		}
+		if (preferenceManager.getClientPreferences().isDefinitionDynamicRegistered()) {
+			registerCapability(Preferences.DEFINITION_ID, Preferences.DEFINITION);
+		}
+		if (preferenceManager.getClientPreferences().isTypeDefinitionDynamicRegistered()) {
+			registerCapability(Preferences.TYPEDEFINITION_ID, Preferences.TYPEDEFINITION);
+		}
+		if (preferenceManager.getClientPreferences().isHoverDynamicRegistered()) {
+			registerCapability(Preferences.HOVER_ID, Preferences.HOVER);
+		}
+		if (preferenceManager.getClientPreferences().isReferencesDynamicRegistered()) {
+			registerCapability(Preferences.REFERENCES_ID, Preferences.REFERENCES);
+		}
+		if (preferenceManager.getClientPreferences().isDocumentHighlightDynamicRegistered()) {
+			registerCapability(Preferences.DOCUMENT_HIGHLIGHT_ID, Preferences.DOCUMENT_HIGHLIGHT);
+		}
+		if (preferenceManager.getClientPreferences().isFoldgingRangeDynamicRegistered()) {
+			registerCapability(Preferences.FOLDINGRANGE_ID, Preferences.FOLDINGRANGE);
+		}
+		if (preferenceManager.getClientPreferences().isWorkspaceFoldersSupported()) {
+			registerCapability(Preferences.WORKSPACE_CHANGE_FOLDERS_ID, Preferences.WORKSPACE_CHANGE_FOLDERS);
+		}
+		if (preferenceManager.getClientPreferences().isImplementationDynamicRegistered()) {
+			registerCapability(Preferences.IMPLEMENTATION_ID, Preferences.IMPLEMENTATION);
+		}
+		try {
+			MethodUtils.invokeMethod((Object)JavaLanguageServerPlugin.getInstance().getProtocol(), "syncCapabilitiesToSettings");
+		} catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+			logException(e.getMessage(), e);
+		}
+		Job initializeWorkspace = new Job("Initialize workspace") {
+
+			@Override
+			public IStatus run(IProgressMonitor monitor) {
+				try {
+					JobHelpers.waitForBuildJobs(60 * 60 * 1000); // 1 hour
+					logInfo(">> build jobs finished");
+					// Dont initialize DiagnosticsHandler here
+				} catch (OperationCanceledException e) {
+					logException(e.getMessage(), e);
+					return Status.CANCEL_STATUS;
+				}
+				return Status.OK_STATUS;
+			}
+		};
+		initializeWorkspace.setPriority(Job.BUILD);
+		initializeWorkspace.setSystem(true);
+		initializeWorkspace.schedule();
 	}
 
 	@Override

--- a/yarn.lock
+++ b/yarn.lock
@@ -1129,15 +1129,15 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0, commander@^2.9.0:
-  version "2.19.0"
-  resolved "http://registry.npm.taobao.org/commander/download/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
-  integrity sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So=
+commander@^2.11.0, commander@^2.20.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
-commander@~2.17.1:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
-  integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
+commander@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.0.tgz#0641ea00838c7a964627f04cddc336a2deddd60a"
+  integrity sha512-pl3QrGOBa9RZaslQiqnnKX2J068wcQw7j9AIaBQ9/JEp5RY6je4jKTImg0Bd+rpoONSe7GUFSgkxLeo17m3Pow==
 
 commondir@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Dont initialize diagnostics handler (#91)