### PR TITLE
[7.x] Delete unnecessary pluginRepository (#98)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,20 +357,4 @@
 			</properties>
 		</profile>
 	</profiles>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>cbi-release</id>
-			<url>https://repo.eclipse.org/content/repositories/cbi-releases/</url>
-		</pluginRepository>
-		<pluginRepository>
-			<id>sonatype-public-repository</id>
-			<url>https://oss.sonatype.org/content/groups/public</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-		</pluginRepository>
-	</pluginRepositories>
 </project>


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Delete unnecessary pluginRepository (#98)