### PR TITLE
Add Jenkins pipeline for Linux and Windows tests

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,0 +1,87 @@
+#!/usr/bin/env groovy
+
+@Library('apm@current') _
+
+pipeline {
+  agent { label 'linux && immutable' }
+  environment {
+    REPO = 'java-langserver'
+    BASE_DIR = "src/github.com/elastic/${env.REPO}"
+    NODE_VERSION="10"
+    YARN_GPG = 'no'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '30', artifactNumToKeepStr: '20'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  triggers {
+    issueCommentTrigger('(?i).*jenkins\\W+run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
+  }
+  stages {
+    stage('Checkout') {
+      options { skipDefaultCheckout() }
+      steps {
+        withGithubNotify(context: 'Checkout') {
+          deleteDir()
+          gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
+          stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+        }
+      }
+    }
+    stage('Build') {
+      parallel {
+        stage('Linux') {
+          options { skipDefaultCheckout() }
+          environment {
+            HOME = "${env.WORKSPACE}"
+            JAVA_HOME = "${env.HUDSON_HOME}/.java/openjdk-12.0.2-linux"
+            PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
+          }
+          steps {
+            withGithubNotify(context: 'Linux tests') {
+              deleteDir()
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                sh(label: 'Run tests', script: './mvnw clean verify')
+              }
+            }
+          }
+          post {
+            always {
+              junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/TEST-*.xml")
+            }
+          }
+        }
+        stage('Windows') {
+          agent { label 'windows-2019-immutable' }
+          options { skipDefaultCheckout() }
+          environment {
+            JAVA_HOME = "C:\\Users\\jenkins\\.java\\openjdk-12.0.2-windows"
+            PATH="${PATH};${env.JAVA_HOME}"
+          }
+          steps {
+            deleteDir()
+            unstash 'source'
+            dir(BASE_DIR) {
+              bat label: 'Run tests', script: './mvnw.cmd clean verify'
+            }
+          }
+          post {
+            always {
+              junit(allowEmptyResults: true, keepLongStdio: true, testResults: "**/TEST-*.xml")
+            }
+          }
+        }
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult()
+    }
+  }
+}

--- a/org.elastic.jdt.ls.tests/pom.xml
+++ b/org.elastic.jdt.ls.tests/pom.xml
@@ -28,6 +28,11 @@
 					</configuration>
 
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>3.0.0-M3</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
## What does this PR do?
It adds a basic Jenkins multi-branch pipeline that runs Maven tests in both Linux and Windows. The CI build will be located under APM-CI instance.

To enable jUnit tests, we are adding Maven Surefire plugin on test POM.

## Future steps
- [ ] Add MacOSX support
- [ ] Run Javascript tests
- [ ] Add Static Analysis checks (precommit, lint, etc)